### PR TITLE
Fix activation bug in directories with spaces

### DIFF
--- a/pyautoenv.py
+++ b/pyautoenv.py
@@ -90,7 +90,7 @@ def main(sys_args: list[str], stdout: TextIO) -> int:
         ) and os.path.isfile(new_activator):
             stdout.write(f"deactivate && . {new_activator}")
     elif new_activator and os.path.isfile(new_activator):
-        stdout.write(f". {new_activator}")
+        stdout.write(f". '{new_activator}'")
     return 0
 
 

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -101,13 +101,13 @@ class PoetryTester(abc.ABC):
         stdout = StringIO()
 
         assert pyautoenv.main([str(self.python_proj), self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {self.venv_dir / self.activator}"
+        assert stdout.getvalue() == f". '{self.venv_dir / self.activator}'"
 
     def test_activates_given_poetry_dir_in_parent(self):
         stdout = StringIO()
 
         assert pyautoenv.main(["python_project/src", self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {self.venv_dir / self.activator}"
+        assert stdout.getvalue() == f". '{self.venv_dir / self.activator}'"
 
     def test_nothing_happens_given_not_venv_dir_and_not_active(self):
         stdout = StringIO()
@@ -189,14 +189,14 @@ class PoetryTester(abc.ABC):
         os.environ["POETRY_CACHE_DIR"] = str(new_poetry_cache_dir)
 
         assert pyautoenv.main(["pyproj2", self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {new_activator}"
+        assert stdout.getvalue() == f". '{new_activator}'"
 
     def test_poetry_cache_dir_env_var_not_used_if_set_and_does_not_exist(self):
         stdout = StringIO()
         os.environ["POETRY_CACHE_DIR"] = "/not/a/dir"
 
         assert pyautoenv.main([str(self.python_proj), self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {self.venv_dir / self.activator}"
+        assert stdout.getvalue() == f". '{self.venv_dir / self.activator}'"
 
     def test_does_nothing_given_poetry_cache_dir_does_not_exist(self, fs):
         stdout = StringIO()

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -73,7 +73,7 @@ class VenvTester(abc.ABC):
         stdout = StringIO()
 
         assert pyautoenv.main([str(self.PY_PROJ), self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {self.VENV_DIR / self.activator}"
+        assert stdout.getvalue() == f". '{self.VENV_DIR / self.activator}'"
 
     def test_activates_if_venv_in_parent(self):
         stdout = StringIO()
@@ -81,7 +81,7 @@ class VenvTester(abc.ABC):
         assert (
             pyautoenv.main([str(self.PY_PROJ / "src"), self.flag], stdout) == 0
         )
-        assert stdout.getvalue() == f". {self.VENV_DIR / self.activator}"
+        assert stdout.getvalue() == f". '{self.VENV_DIR / self.activator}'"
 
     def test_nothing_happens_given_venv_dir_is_already_active(self):
         stdout = StringIO()
@@ -156,14 +156,14 @@ class VenvTester(abc.ABC):
         os.environ["PYAUTOENV_VENV_NAME"] = "foo;venv;other_venv"
 
         assert pyautoenv.main([str(self.PY_PROJ), self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {venv_activate}"
+        assert stdout.getvalue() == f". '{venv_activate}'"
 
     def test_venv_dir_name_environment_variable_ignored_if_set_but_empty(self):
         stdout = StringIO()
         os.environ["PYAUTOENV_VENV_NAME"] = ""
 
         assert pyautoenv.main([str(self.PY_PROJ), self.flag], stdout) == 0
-        assert stdout.getvalue() == f". {self.VENV_DIR / self.activator}"
+        assert stdout.getvalue() == f". '{self.VENV_DIR / self.activator}'"
 
     def test_nothing_happens_given_changing_to_ignored_directory(self):
         stdout = StringIO()


### PR DESCRIPTION
Environments within paths that contain spaces were not being activated. 

The attempted activation resulted in an error, caused by word splitting.