### PR TITLE
Add support for poetry v2 pyproject format

### DIFF
--- a/pyautoenv.py
+++ b/pyautoenv.py
@@ -32,7 +32,7 @@ import sys
 from functools import lru_cache
 from typing import List, TextIO, Union
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 CLI_HELP = f"""usage: pyautoenv [-h] [-V] [--fish | --pwsh] [directory]
 {__doc__}

--- a/pyautoenv.py
+++ b/pyautoenv.py
@@ -351,7 +351,7 @@ def poetry_project_name(directory: str) -> Union[str, None]:
     # hacked together parser should work for the vast majority of cases.
     in_tool_poetry_section = False
     for line in pyproject_lines:
-        if line.strip() == "[tool.poetry]":
+        if line.strip() in ["[tool.poetry]", "[project]"]:
             in_tool_poetry_section = True
             continue
         if line.strip().startswith("["):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyautoenv"
-version = "0.6.1"
+version = "0.6.2"
 description = "Print a command to activate or deactivate a Python venv based on a directory."
 authors = ["Harry Saunders <33317174+hsaunders1904@users.noreply.github.com>"]
 license = "GPL-3"

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -143,10 +143,20 @@ class PoetryTester(abc.ABC):
         )
         assert stdout.getvalue() == "deactivate"
 
-    def test_deactivate_and_activate_switching_to_new_poetry_env(self, fs):
+    @pytest.mark.parametrize("name_in_project_section", [True, False])
+    def test_deactivate_and_activate_switching_to_new_poetry_env(
+        self,
+        fs,
+        name_in_project_section,
+    ):
         stdout = StringIO()
         activate_venv(self.venv_dir)
-        fs = make_poetry_project(fs, "pyproj2", Path("pyproj2"))
+        fs = make_poetry_project(
+            fs,
+            "pyproj2",
+            Path("pyproj2"),
+            name_in_project_section=name_in_project_section,
+        )
         if os.name == "nt":
             new_venv = self.poetry_cache / "pyproj2-lbvqfyck-py3.8"
         else:

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -33,6 +33,8 @@ def make_poetry_project(
     fs: FakeFilesystem,
     name: str,
     path: Path,
+    *,
+    name_in_project_section: bool = False,
 ) -> FakeFilesystem:
     """Create a poetry project on the given file system."""
     fs.create_file(path / "poetry.lock")
@@ -41,8 +43,8 @@ def make_poetry_project(
         'requires = ["poetry-core>=1.0.0"]\n'
         'build-backend = "poetry.core.masonry.api"\n'
         "\n"
-        "[tool.poetry]\n"
-        "# comment\n"
+        + ("[project]\n" if name_in_project_section else "[tool.poetry]\n")
+        + "# comment\n"
         'names = "not this one!"\n'
         f'name = "{name}"\n'
         'version = "0.2.0"\n'


### PR DESCRIPTION
In version 2 of poetry, the name of the project can now be declared in the `[project]` section of the `pyproject.toml` file. This commit adds support for reading the project name from this section.